### PR TITLE
Change pragma omp private to not include 'nod' as it does not seem to be a used variable

### DIFF
--- a/TUNAMIFF-CUDA-Version-2011-05-21/source code/MASSGBOUNDMOMENT.cpp
+++ b/TUNAMIFF-CUDA-Version-2011-05-21/source code/MASSGBOUNDMOMENT.cpp
@@ -243,7 +243,7 @@ zoutAT
   CNode& Node = *gNode;
 
   // sea floor topography (mass conservation)
-  #pragma omp parallel for default(shared) private(i,j,nod,absH)
+  #pragma omp parallel for default(shared) private(i,j,m,absH)
   for( i=Imin; i<=Imax; i++ ) {
     for( j=Jmin; j<=Jmax; j++ ) {
 
@@ -312,7 +312,7 @@ zoutAT
 
   // moment conservation
   // longitudial flux update
-  #pragma omp parallel for default(shared) private(i,j,nod,v1,v2)
+  #pragma omp parallel for default(shared) private(i,j,m,v1,v2)
   for( i=Imin; i<=Imax; i++ ) {
     for( j=Jmin; j<=Jmax; j++ ) {
 
@@ -346,7 +346,7 @@ zoutAT
   }
 
   // lattitudial flux update
-  #pragma omp parallel for default(shared) private(i,j,nod,v1,v2)
+  #pragma omp parallel for default(shared) private(i,j,m,v1,v2)
   for( i=Imin; i<=Imax; i++ ) {
     for( j=Jmin; j<=Jmax; j++ ) {
 


### PR DESCRIPTION
Fixes compiler errors about unused variable when using -fopenmp